### PR TITLE
Exposes the total pages attribute

### DIFF
--- a/lib/paid/api_list.rb
+++ b/lib/paid/api_list.rb
@@ -3,6 +3,7 @@ module Paid
     include Enumerable
 
     attr_reader :data
+    attr_reader :total_pages
     attr_reader :klass
 
     def initialize(klass, json={}, api_method=nil)
@@ -80,7 +81,8 @@ module Paid
 
 
     @api_attributes = {
-      :data => { :readonly => true }
+      :data => { :readonly => true },
+      :total_pages => { :readonly => true }
     }
   end
 end


### PR DESCRIPTION
Why:

* Knowing how many pages are left is useful when traversing a paginated
  collection in the API, saving us a request in which we'd get an empty
  array at the end. It turns out that the API is already returning such
  a field, but the library is not exposing it.

This change addresses the need by:

* Exposing the `total_pages` API attribute and marking it as read only